### PR TITLE
Replace duplicate name error with console.warn

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "react/jsx-filename-extension": 0,
     "linebreak-style": 0,
     "no-underscore-dangle": 0,
+    "no-console": 0,
     "import/first": "off",
     "import/order": ["error", {
       "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],

--- a/src/withInitAction.js
+++ b/src/withInitAction.js
@@ -80,7 +80,7 @@ export default (p1, p2, p3) => {
       throw new Error('withInitAction() HoC requires the wrapped component to have a displayName');
     }
     if (componentIds.includes(componentId)) {
-      throw new Error(`Each Component passed to withInitAction() should have a unique displayName. Found duplicate name "${componentId}"`);
+      console.warn(`Each Component passed to withInitAction() should have a unique displayName. Found duplicate name "${componentId}"`);
     }
     componentIds.push(componentId);
 

--- a/tests/withInitAction.spec.js
+++ b/tests/withInitAction.spec.js
@@ -109,30 +109,4 @@ describe('withInitAction', () => {
     )(FooComponent);
     expect(WithInit.initConfig.initProps).toEqual(['a', 'b', 'c']);
   });
-
-  it('throws an error when two components with the same displayName are passed', () => {
-    clearComponentIds();
-    class BarComponent extends Component {
-      render() {
-        return <noscript />;
-      }
-    }
-
-    class BarComponent2 extends Component {
-      static displayName = 'BarComponent';
-
-      render() {
-        return <noscript />;
-      }
-    }
-
-    // eslint-disable-next-line no-unused-vars
-    const WithInit = withInitAction(() => Promise.resolve())(BarComponent);
-    expect(() => {
-      // eslint-disable-next-line no-unused-vars
-      const WithInit2 = withInitAction(
-        () => Promise.resolve(),
-      )(BarComponent2);
-    }).toThrow();
-  });
 });


### PR DESCRIPTION
When using hot module reloading, a new module will often be defined under the same name. In that case, we don't want to throw an error. Replace the error with a warning.