### PR TITLE
Add option to generate custom prepare key

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Higher-order component that adds initialization configuration to an existing com
      - `"UNMOUNT"` same as `"BLOCKING"` but it will also unmount the component during re-initialization.
      - `"NEVER"` will only initialize on the server (`initMode == MODE_PREPARE`). Initialization will be skipped on the client.
    - `onError` Error handler for errors in `initAction`.  If given, errors will be swallowed.
+   - `getPrepareKey` A function that generates a "prepare key" that will be used to uniquely identify a component and its props. It has the following signature:
+  `({string} componentId, {Array} propsArray) => {string}`
+  This defaults to a function that concatenates the `componentId` and the stringified `propsArray`. In most cases, this will ensure that a component instance on the server is matched to the corresponding instance on the client. However, if the props are somehow always different between server and client, you may use this function to generate a key that omits that difference.
    - `getInitState` A function that takes the Redux state and returns the init state of the reducer from this module. By default, it is assumed the state is under the `init` property. If the reducer is included elsewhere, this function can be set to retrieve the state.
 
 #### example

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Higher-order component that adds initialization configuration to an existing com
      - `"NEVER"` will only initialize on the server (`initMode == MODE_PREPARE`). Initialization will be skipped on the client.
    - `onError` Error handler for errors in `initAction`.  If given, errors will be swallowed.
    - `getPrepareKey` A function that generates a "prepare key" that will be used to uniquely identify a component and its props. It has the following signature:
-  `({string} componentId, {Array} propsArray) => {string}`
+  ```({string} componentId, {Array} propsArray) => {string}```
   This defaults to a function that concatenates the `componentId` and the stringified `propsArray`. In most cases, this will ensure that a component instance on the server is matched to the corresponding instance on the client. However, if the props are somehow always different between server and client, you may use this function to generate a key that omits that difference.
    - `getInitState` A function that takes the Redux state and returns the init state of the reducer from this module. By default, it is assumed the state is under the `init` property. If the reducer is included elsewhere, this function can be set to retrieve the state.
 

--- a/src/actions/prepareComponent.js
+++ b/src/actions/prepareComponent.js
@@ -1,6 +1,5 @@
 import { MODE_PREPARE } from '../initMode';
 import extractValuesForProps from '../utils/extractValuesForProps';
-import createPrepareKey from '../utils/createPrepareKey';
 
 import initComponent from './initComponent';
 
@@ -29,7 +28,7 @@ export default (Component, props = {}) =>
       const {
         componentId,
         initProps,
-        options: { getInitState },
+        options: { getInitState, getPrepareKey },
       } = Component.initConfig;
 
       const initState = getInitState(getState());
@@ -47,7 +46,7 @@ export default (Component, props = {}) =>
           }
         });
 
-        const prepareKey = createPrepareKey(componentId, initValues);
+        const prepareKey = getPrepareKey(componentId, initValues);
 
         return dispatch(initComponent(Component, initValues, prepareKey, {
           isPrepare: true,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,6 @@ import { createSelector } from 'reselect';
 import createShallowArrayCompareSelector from './utils/createShallowArrayCompareSelector';
 import { INIT_COMPONENT, SET_INIT_MODE } from './actions/actionTypes';
 import extractValuesForProps from './utils/extractValuesForProps';
-import createPrepareKey from './utils/createPrepareKey';
 import { MODE_PREPARE } from './initMode';
 
 /**
@@ -44,11 +43,11 @@ export default (state = {
   }
 };
 
-const createComponentInitValuesSelector = ({ componentId, initProps }) =>
+const createComponentInitValuesSelector = ({ componentId, initProps, options: { getPrepareKey } }) =>
   createShallowArrayCompareSelector(
     (state, props) => extractValuesForProps(props, initProps),
     initValues => ({
-      prepareKey: createPrepareKey(componentId, initValues),
+      prepareKey: getPrepareKey(componentId, initValues),
       initValues,
     }),
   );

--- a/src/withInitAction.js
+++ b/src/withInitAction.js
@@ -12,6 +12,7 @@ import {
   INIT_SELF_UNMOUNT,
   INIT_SELF_BLOCKING,
 } from './initSelfMode';
+import createPrepareKey from './utils/createPrepareKey';
 
 const componentIds = [];
 
@@ -51,6 +52,13 @@ const componentIds = [];
  *   be skipped on the client.
  * @param {function} [options.onError] Error handler for errors that occur while executing
  * initAction. If given, errors will be swallowed.
+ * @param {function} [options.getPrepareKey] A function that generates a "prepare key" that will be
+ * used to uniquely identify a component and its props. It has the following signature:
+ * `({string} componentId, {Array} propsArray) => {string}`
+ * This defaults to a function that concatenates the `componentId` and the stringified `propsArray`.
+ * In most cases, this will ensure that a component instance on the server is matched to the
+ * corresponding instance on the client. However, if the props are somehow always different between
+ * server and client, you may use this function to generate a key that omits that difference.
  * @param {function} [options.getInitState] A function that takes the Redux state and returns
  * the init state of the reducer from this module. By default, it is assumed that the state is
  * under the "init" property. If the reducer is included elsewhere, this function can be set
@@ -71,6 +79,7 @@ export default (p1, p2, p3) => {
     reinitialize = true,
     onError,
     getInitState = defaultGetInitState,
+    getPrepareKey = createPrepareKey,
     initSelf = INIT_SELF_ASYNC,
     allowLazy = false,
   } = options;
@@ -89,7 +98,7 @@ export default (p1, p2, p3) => {
       componentId,
       initProps,
       initAction,
-      options: { reinitialize, onError, getInitState, initSelf, allowLazy },
+      options: { reinitialize, onError, getInitState, initSelf, allowLazy, getPrepareKey },
     };
 
     class WithInit extends Component {

--- a/tests/actions/prepareComponent.spec.js
+++ b/tests/actions/prepareComponent.spec.js
@@ -42,6 +42,30 @@ describe('prepareComponent', () => {
       ]);
     }));
   });
+  describe('with a custom getPrepareKey', () => {
+    clearComponentIds();
+    const store = mockStore({ init: { mode: MODE_PREPARE, prepared: {} } });
+    const MockComponent = () => <script />;
+    const MockWithInit = withInitAction(
+      () => Promise.resolve(),
+      {
+        getPrepareKey: componentId => `${componentId}!foobar`,
+      },
+    )(MockComponent);
+    const preparePromise = store.dispatch(prepareComponent(MockWithInit, {}));
+    it('should dispatch INIT_COMPONENT actions with the correct prepareKey', () => preparePromise.then(() => {
+      expect(store.getActions()).toEqual([
+        {
+          type: INIT_COMPONENT,
+          payload: { complete: false, isPrepare: true, prepareKey: 'MockComponent!foobar' },
+        },
+        {
+          type: INIT_COMPONENT,
+          payload: { complete: true, isPrepare: true, prepareKey: 'MockComponent!foobar' },
+        },
+      ]);
+    }));
+  });
   describe('with a component configured with allowLazy', () => {
     clearComponentIds();
     const store = mockStore({ init: { mode: MODE_PREPARE, prepared: {} } });


### PR DESCRIPTION
In some edge cases the `initProps` passed to a component are slightly different on the server and the client.  This is mainly an issue with large objects passed by external libraries such as `react-router`. Added an `getPrepareKey` option so we can override the default key generator function for component instances, and pass a function that ignores the invariants between server and client.