### PR TITLE
Dispatch INIT_COMPONENT complete on error

### DIFF
--- a/src/actions/initComponent.js
+++ b/src/actions/initComponent.js
@@ -87,6 +87,14 @@ export default (
         if (onError && !e.isInvalidReturnError) {
           onError(e);
         } else {
+          dispatch({
+            type: INIT_COMPONENT,
+            payload: {
+              complete: true,
+              isPrepare,
+              prepareKey,
+            },
+          });
           throw e;
         }
       })


### PR DESCRIPTION
Before re-throwing an initAction error, dispatch INIT_COMPONENT
complete to make sure the reducer state does not get stuck in a
complete: false state.