### PR TITLE
Fix selector

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -43,7 +43,9 @@ export default (state = {
   }
 };
 
-const createComponentInitValuesSelector = ({ componentId, initProps, options: { getPrepareKey } }) =>
+const createComponentInitValuesSelector = ({
+  componentId, initProps, options: { getPrepareKey },
+}) =>
   createShallowArrayCompareSelector(
     (state, props) => extractValuesForProps(props, initProps),
     initValues => ({

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import createShallowArrayCompareSelector from './utils/createShallowArrayCompareSelector';
+import createShallowEqualSelector from './utils/createShallowEqualSelector';
 import { INIT_COMPONENT, SET_INIT_MODE } from './actions/actionTypes';
 import extractValuesForProps from './utils/extractValuesForProps';
 import { MODE_PREPARE } from './initMode';
@@ -45,16 +45,15 @@ export default (state = {
 
 const createComponentInitValuesSelector = ({
   componentId, initProps, options: { getPrepareKey },
-}) =>
-  createShallowArrayCompareSelector(
-    (state, props) => extractValuesForProps(props, initProps),
-    initValues => ({
-      prepareKey: getPrepareKey(componentId, initValues),
-      initValues,
-    }),
-  );
+}) => createShallowEqualSelector(
+  (state, props) => extractValuesForProps(props, initProps),
+  initValues => ({
+    prepareKey: getPrepareKey(componentId, initValues),
+    initValues,
+  }),
+);
 
-export const createComponentInitStateSelector = initConfig => createSelector(
+const createComponentInitStateHelperSelector = initConfig => createSelector(
   createComponentInitValuesSelector(initConfig),
   state => state.selfInit,
   state => state.prepared,
@@ -62,6 +61,16 @@ export const createComponentInitStateSelector = initConfig => createSelector(
     prepareKey,
     initValues,
     selfInitState: selfInit[prepareKey],
-    isPrepared: !!prepared[prepareKey],
+    preparedState: prepared[prepareKey],
+  }),
+);
+
+export const createComponentInitStateSelector = initConfig => createShallowEqualSelector(
+  createComponentInitStateHelperSelector(initConfig),
+  ({ prepareKey, initValues, selfInitState, preparedState }) => ({
+    prepareKey,
+    initValues,
+    selfInitState,
+    isPrepared: !!preparedState,
   }),
 );

--- a/src/utils/createShallowArrayCompareSelector.js
+++ b/src/utils/createShallowArrayCompareSelector.js
@@ -1,9 +1,0 @@
-import { createSelectorCreator, defaultMemoize } from 'reselect';
-
-export default createSelectorCreator(
-  defaultMemoize,
-  (a, b) => (
-    (a.length === b.length) &&
-    a.every((val, index) => (val === b[index]))
-  ),
-);

--- a/src/utils/createShallowEqualSelector.js
+++ b/src/utils/createShallowEqualSelector.js
@@ -1,0 +1,31 @@
+import { createSelectorCreator, defaultMemoize } from 'reselect';
+
+function isShallowEqual(a, b) {
+  if ((typeof a !== 'object') || (typeof b !== 'object')) {
+    return a === b;
+  }
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+
+  if (aIsArray !== bIsArray) {
+    return false;
+  }
+
+  if (aIsArray) {
+    return (a.length === b.length) && a.every((val, index) => val === b[index]);
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  return keysA.every(key => (a[key] === b[key]));
+}
+
+const createShallowEqualSelector = createSelectorCreator(defaultMemoize, isShallowEqual);
+
+export default createShallowEqualSelector;

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"import/no-extraneous-dependencies": 0
+	}
+}


### PR DESCRIPTION
Replace createShallowArrayCompareSelector with createShallowEqualSelector, which can handle both object and array equality checks.

Wrap the selector in a new selector that does a shallow equality check. This will ensure that the selector does not recompute its output when state.selfInit or state.prepared changes in keys that are not related to the current prepareKey

Fixes #24 